### PR TITLE
Change window scroll to page offset

### DIFF
--- a/js/lib/Plugins/Chaser.js
+++ b/js/lib/Plugins/Chaser.js
@@ -193,8 +193,8 @@ var Sushi;
 		limitPosition += this.scrollTrigger.getOffset();
 
 		var isLimited = (this.options.inverted
-			? (limitPosition > window.scrollY)
-			: (limitPosition < window.scrollY)
+			? (limitPosition > window.pageYOffset)
+			: (limitPosition < window.pageYOffset)
 		);
 
 		if (isLimited) {

--- a/js/lib/Util/Css.js
+++ b/js/lib/Util/Css.js
@@ -161,10 +161,10 @@ var Sushi;
 
 	Css.getOffset = function (element, context) {
 		var contextRect = {
-			top: -window.scrollY,
-			right: -window.scrollX + document.documentElement.clientWidth,
-			bottom: -window.scrollY + document.documentElement.clientHeight,
-			left: -window.scrollX,
+			top: -window.pageYOffset,
+			right: -window.pageXOffset + document.documentElement.clientWidth,
+			bottom: -window.pageYOffset + document.documentElement.clientHeight,
+			left: -window.pageXOffset,
 		};
 		var elementRect = element.getBoundingClientRect();
 


### PR DESCRIPTION
This fixes bugs happening in IE.
pageYOffset and pageXOffset are read-only window properties that return
the number of pixels the document has been scrolled vertically.
And scrollY and scrollX are the exactly same thing. The main difference
is that there is better cross-browser compatibility for
page[axis]Offset than scroll[axis].