### PR TITLE
Add 'configurable' property on missing polyfills

### DIFF
--- a/js/polyfills/Array.prototype.includes.js
+++ b/js/polyfills/Array.prototype.includes.js
@@ -8,6 +8,7 @@ if (Array.prototype.includes === void 0) {
 
 	// eslint-disable-next-line no-extend-native
 	Object.defineProperty(Array.prototype, "includes", {
+		configurable: true,
 		value: function (searchElement, fromIndex) {
 			// 1. Let O be ? ToObject(this value).
 			if (this == null) {

--- a/js/polyfills/String.prototype.includes.js
+++ b/js/polyfills/String.prototype.includes.js
@@ -6,6 +6,7 @@ if (String.prototype.includes === void 0) {
 	console.warn("Polyfilling String.prototype.includes");
 
 	Object.defineProperty(String.prototype, "includes", {
+		configurable: true,
 		value: function (search, start) {
 			if (typeof start !== "number") {
 				start = 0;


### PR DESCRIPTION
This PR fixes the error `TypeError: can't redefine non-configurable property "x"`. It happens when Sushi Bazooka's polyfills conflict with polyfills from other libraries.

See: [MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_redefine_property)